### PR TITLE
Support changing tag name for FlexContainer and FlexItem

### DIFF
--- a/src/components/FlexContainer.tsx
+++ b/src/components/FlexContainer.tsx
@@ -7,7 +7,7 @@ import { checkOverlapping } from '../helpers/overlapping'
 import { trimUndefined } from '../helpers/trim'
 
 // Types
-import type { FlexContainerProps } from '../index'
+import type { ContainerTags, FlexContainerProps } from "../index";
 
 function FlexContainer({
   // 'display'
@@ -67,6 +67,9 @@ function FlexContainer({
 
   // 'flex-flow'
   flow,
+
+  // tag name
+  as: tagName,
 
   // required
   style = {},
@@ -208,10 +211,11 @@ function FlexContainer({
     ...style,
   })
 
+  const Tag = (tagName ?? 'div') as keyof ContainerTags
   return (
-    <div style={combinedStyle} {...rest}>
+    <Tag style={combinedStyle} {...rest}>
       {children}
-    </div>
+    </Tag>
   )
 }
 

--- a/src/components/FlexContainer.tsx
+++ b/src/components/FlexContainer.tsx
@@ -7,7 +7,7 @@ import { checkOverlapping } from '../helpers/overlapping'
 import { trimUndefined } from '../helpers/trim'
 
 // Types
-import type { ContainerTags, FlexContainerProps } from "../index";
+import type { FlexContainerProps, ContainerTags } from '../index'
 
 function FlexContainer({
   // 'display'

--- a/src/components/FlexItem.tsx
+++ b/src/components/FlexItem.tsx
@@ -7,7 +7,7 @@ import { checkOverlapping } from '../helpers/overlapping'
 import { trimUndefined } from '../helpers/trim'
 
 // Types
-import type { ContainerTags, FlexItemProps } from "../index";
+import type { FlexItemProps, ContainerTags } from '../index'
 
 function FlexItem({
   // 'order'

--- a/src/components/FlexItem.tsx
+++ b/src/components/FlexItem.tsx
@@ -7,7 +7,7 @@ import { checkOverlapping } from '../helpers/overlapping'
 import { trimUndefined } from '../helpers/trim'
 
 // Types
-import type { FlexItemProps } from '../index'
+import type { ContainerTags, FlexItemProps } from "../index";
 
 function FlexItem({
   // 'order'
@@ -34,6 +34,9 @@ function FlexItem({
   alignSelfStretch,
   // 'align-self' manual
   alignSelf,
+
+  // tag name
+  as: tagName,
 
   // required
   style = {},
@@ -93,10 +96,11 @@ function FlexItem({
     ...style,
   })
 
+  const Tag = (tagName ?? 'div') as keyof ContainerTags
   return (
-    <div style={combinedStyle} {...rest}>
+    <Tag style={combinedStyle} {...rest}>
       {children}
-    </div>
+    </Tag>
   )
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 // Libraries
 import type { Property } from 'csstype'
 
-type DivProps = React.DetailedHTMLProps<React.HTMLAttributes<HTMLDivElement>, HTMLDivElement>
+type ContainerProps<ContainerType> = React.DetailedHTMLProps<React.HTMLAttributes<ContainerType>, ContainerType>
 
 export interface IndexableCSS extends React.CSSProperties {
   [key: string]: string | number | undefined
@@ -153,6 +153,16 @@ type ColumnGapCSS = {
   columnGap?: Property.ColumnGap
 }
 
+export type ContainerTags = Pick<
+  JSX.IntrinsicElements,
+  'div' | 'nav' | 'main' | 'aside' | 'article' | 'header' | 'section' | 'footer'
+>
+
+type TagName = {
+  // as property for change default div to any html tags
+  as?: keyof ContainerTags
+}
+
 type AlignSelfCSS =
   | {
       // 'align-self' short
@@ -175,7 +185,7 @@ type AlignSelfCSS =
       alignSelf?: Property.AlignSelf
     }
 
-export type FlexContainerProps = DivProps &
+export type FlexContainerProps<ContainerType = HTMLDivElement> = ContainerProps<ContainerType> &
   DisplayCSS &
   FlexDirectionCSS &
   FlexWrapCSS &
@@ -185,6 +195,14 @@ export type FlexContainerProps = DivProps &
   FlexFlowCSS &
   GapCSS &
   RowGapCSS &
-  ColumnGapCSS
+  ColumnGapCSS &
+  TagName
 
-export type FlexItemProps = DivProps & OrderCSS & FlexGrowCSS & FlexShrinkCSS & FlexBasisCSS & FlexCSS & AlignSelfCSS
+export type FlexItemProps<ContainerType = HTMLDivElement> = ContainerProps<ContainerType> &
+  OrderCSS &
+  FlexGrowCSS &
+  FlexShrinkCSS &
+  FlexBasisCSS &
+  FlexCSS &
+  AlignSelfCSS &
+  TagName

--- a/src/tests/components/FlexContainer.test.tsx
+++ b/src/tests/components/FlexContainer.test.tsx
@@ -21,6 +21,16 @@ describe('<FlexContainer /> - General', () => {
     matchesSnapshot(component, snapshot)
   })
 
+  it('renders an empty flex container with tagName', async () => {
+    const component = <FlexContainer as={'main'} />
+    const snapshot = `
+<main
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
   it('applies custom style to the div', async () => {
     const component = (
       <FlexContainer

--- a/src/tests/components/FlexContainer.test.tsx
+++ b/src/tests/components/FlexContainer.test.tsx
@@ -22,7 +22,7 @@ describe('<FlexContainer /> - General', () => {
   })
 
   it('renders an empty flex container with tagName', async () => {
-    const component = <FlexContainer as={'main'} />
+    const component = <FlexContainer as='main' />
     const snapshot = `
 <main
   style="display: flex;"
@@ -85,7 +85,99 @@ describe('<FlexContainer /> - General', () => {
   })
 })
 
-describe('<FlexContainer /> - Inline', () => {
+describe('<FlexContainer /> - as', () => {
+  it('defaults to rendering as a <div/>', async () => {
+    const component = <FlexContainer />
+    const snapshot = `
+<div
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders explicitly as a <div/>', async () => {
+    const component = <FlexContainer as='div' />
+    const snapshot = `
+<div
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <nav/>', async () => {
+    const component = <FlexContainer as='nav' />
+    const snapshot = `
+<nav
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <main/>', async () => {
+    const component = <FlexContainer as='main' />
+    const snapshot = `
+<main
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as an <aside/>', async () => {
+    const component = <FlexContainer as='aside' />
+    const snapshot = `
+<aside
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as an <article/>', async () => {
+    const component = <FlexContainer as='article' />
+    const snapshot = `
+<article
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <header/>', async () => {
+    const component = <FlexContainer as='header' />
+    const snapshot = `
+<header
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <section/>', async () => {
+    const component = <FlexContainer as='section' />
+    const snapshot = `
+<section
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <footer/>', async () => {
+    const component = <FlexContainer as='footer' />
+    const snapshot = `
+<footer
+  style="display: flex;"
+/>
+`
+    matchesSnapshot(component, snapshot)
+  })
+})
+
+describe('<FlexContainer /> - inline', () => {
   it('renders an empty inline flex container', async () => {
     const component = <FlexContainer inline />
     const snapshot = `

--- a/src/tests/components/FlexItem.test.tsx
+++ b/src/tests/components/FlexItem.test.tsx
@@ -17,6 +17,12 @@ describe('<FlexItem /> - General', () => {
     matchesSnapshot(component, snapshot)
   })
 
+  it('renders an empty flex item with tagName', async () => {
+    const component = <FlexItem as={'section'} />
+    const snapshot = `<section />`
+    matchesSnapshot(component, snapshot)
+  })
+
   it('applies custom style to the div', async () => {
     const component = (
       <FlexItem

--- a/src/tests/components/FlexItem.test.tsx
+++ b/src/tests/components/FlexItem.test.tsx
@@ -18,7 +18,7 @@ describe('<FlexItem /> - General', () => {
   })
 
   it('renders an empty flex item with tagName', async () => {
-    const component = <FlexItem as={'section'} />
+    const component = <FlexItem as='section' />
     const snapshot = `<section />`
     matchesSnapshot(component, snapshot)
   })
@@ -57,6 +57,62 @@ describe('<FlexItem /> - General', () => {
 
     fireEvent.click(await findByTestId('flex-item'))
     expect(onClick).toHaveBeenCalled()
+  })
+})
+
+describe('<FlexItem /> - as', () => {
+  it('defaults to rendering as a <div/>', async () => {
+    const component = <FlexItem />
+    const snapshot = `<div />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders explicitly as a <div/>', async () => {
+    const component = <FlexItem as='div' />
+    const snapshot = `<div />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <nav/>', async () => {
+    const component = <FlexItem as='nav' />
+    const snapshot = `<nav />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <main/>', async () => {
+    const component = <FlexItem as='main' />
+    const snapshot = `<main />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as an <aside/>', async () => {
+    const component = <FlexItem as='aside' />
+    const snapshot = `<aside />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as an <article/>', async () => {
+    const component = <FlexItem as='article' />
+    const snapshot = `<article />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <header/>', async () => {
+    const component = <FlexItem as='header' />
+    const snapshot = `<header />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <section/>', async () => {
+    const component = <FlexItem as='section' />
+    const snapshot = `<section />`
+    matchesSnapshot(component, snapshot)
+  })
+
+  it('renders as a <footer/>', async () => {
+    const component = <FlexItem as='footer' />
+    const snapshot = `<footer />`
+    matchesSnapshot(component, snapshot)
   })
 })
 

--- a/src/tests/components/FlexWrapper.test.tsx
+++ b/src/tests/components/FlexWrapper.test.tsx
@@ -111,4 +111,34 @@ describe('<FlexWrapper />', () => {
 `
     matchesSnapshot(component, snapshot)
   })
+
+  it('renders a flex container with flex items, rendered as different tag names', async () => {
+    const component = (
+      <Flex as='main' column alignItemsCenter>
+        <Flex.Item as='section' alignSelfStretch>
+          Item 1
+        </Flex.Item>
+        <Flex.Item as='section' alignSelfStretch>
+          Item 2
+        </Flex.Item>
+      </Flex>
+    )
+    const snapshot = `
+<main
+  style="display: flex; flex-direction: column; align-items: center;"
+>
+  <section
+    style="align-self: stretch;"
+  >
+    Item 1
+  </section>
+  <section
+    style="align-self: stretch;"
+  >
+    Item 2
+  </section>
+</main>
+`
+    matchesSnapshot(component, snapshot)
+  })
 })


### PR DESCRIPTION
Added `as` property for change default `div` tag to `nav,  main,  aside,  article, header, section or footer`  

Example:  
```jsx
<Flex as={'main'}>
    <Flex.Item as={'section'} />
    <Flex.Item as={'section'} />
</Flex>
```

```html
<main style="display: flex;" >
    <section />
    <section />
</main>
```
